### PR TITLE
fix: repair href link for user handle

### DIFF
--- a/src/components/setSolvedacInfo.js
+++ b/src/components/setSolvedacInfo.js
@@ -10,5 +10,5 @@ export const setSolvedacInfo = (tier, handle) => {
   chrome.storage.local.set({ handle, tier })
   tierImgElement.src = `${STATIC_SOLVEDAC_URL}/tier_small/${tier}.svg`
   userHandleElement.innerText = handle
-  userHandleElement.href = `${BOJ_RANDOM_DEFENSE_CLIENT_URL}/${handle}`
+  userHandleElement.href = `${BOJ_RANDOM_DEFENSE_CLIENT_URL}/user/${handle}`
 }


### PR DESCRIPTION
The user handle hyperlinks are incorrectly formatted as {URL}/{user-handle}, while the correct format should be {URL}/user/{user-handle}. This commit fixes the issue to make the hyperlinks are correct.

